### PR TITLE
Loadscenes data.forEach hatasını onar

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>Yes or GOAL!</title>
     <link rel="stylesheet" href="style.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
@@ -125,6 +128,6 @@
         </div>
     </div>
 
-    <script src="script.js"></script>
+    <script src="script.js?v=1.1"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,14 +2,36 @@ let scenes = {};
 let currentSceneId = "scene1";
 
 async function loadScenes() {
-  const response = await fetch("scenes.json");
-  const data = await response.json();
-  scenes = data;   // forEach YOK, direk ata!
-  loadScene(currentSceneId);
+  try {
+    const response = await fetch("scenes.json");
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    
+    // Ensure data is an object with scenes
+    if (typeof data !== 'object' || data === null) {
+      throw new Error('Invalid JSON data format');
+    }
+    
+    scenes = data;
+    console.log('Scenes loaded successfully:', Object.keys(scenes).length, 'scenes');
+    loadScene(currentSceneId);
+  } catch (error) {
+    console.error('Error loading scenes:', error);
+    document.getElementById("scene-title").innerText = "Hata!";
+    document.getElementById("scene-text").innerText = "Oyun yüklenirken bir hata oluştu. Lütfen sayfayı yenileyin.";
+  }
 }
 
 function loadScene(id) {
   const scene = scenes[id];
+  if (!scene) {
+    console.error('Scene not found:', id);
+    document.getElementById("scene-title").innerText = "Hata!";
+    document.getElementById("scene-text").innerText = `Sahne bulunamadı: ${id}`;
+    return;
+  }
   currentSceneId = id;
 
   // Görsel gösterme


### PR DESCRIPTION
Fix `data.forEach is not a function` error by adding cache-busting and robust error handling for scene loading.

The `TypeError` was caused by the browser serving a cached, outdated version of `script.js` that contained an incorrect `forEach` call on the JSON data, even though the local file was updated. This PR adds cache-busting measures and comprehensive error handling to prevent this and similar issues.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-70833190-4c1d-4099-8cbd-e26e130617c9) · [Cursor](https://cursor.com/background-agent?bcId=bc-70833190-4c1d-4099-8cbd-e26e130617c9)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)