### PR TITLE
Investigate 404 resource failure

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,10 +35,14 @@ function loadScene(id) {
   currentSceneId = id;
 
   // Görsel gösterme
-  if (scene.image && scene.image.length <= 3) {
-    document.getElementById("scene-image").innerText = scene.image;
-  } else if (scene.image) {
-    document.getElementById("scene-image").innerHTML = `<img src="images/${scene.image}" alt="Sahne Görseli" />`;
+  if (scene.image) {
+    // Check if it's an emoji or contains emoji characters (no file extension)
+    if (!scene.image.includes('.')) {
+      document.getElementById("scene-image").innerText = scene.image;
+    } else {
+      // Only try to load as image if it has a file extension
+      document.getElementById("scene-image").innerHTML = `<img src="images/${scene.image}" alt="Sahne Görseli" />`;
+    }
   }
 
   document.getElementById("scene-title").innerText = scene.title || "";


### PR DESCRIPTION
Fix 404 errors by correcting emoji vs. image file detection in `script.js`.

The previous logic incorrectly assumed that image strings with a length of 3 or less were emojis, leading to attempts to load longer encoded emojis as non-existent image files from the `images/` directory. The updated logic now checks for the presence of a file extension to correctly distinguish between emojis and actual image paths.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-00d9ada0-4030-4a71-b64b-0ca17fb7b643) · [Cursor](https://cursor.com/background-agent?bcId=bc-00d9ada0-4030-4a71-b64b-0ca17fb7b643)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)